### PR TITLE
Create the directory for the stats file if it doesn't exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 /test/output/
+/test/new-output/

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 var fs = require('fs');
+var mkdirp = require('mkdirp');
+var path = require('path');
 
 var StatsPlugin = function (output, options) {
   this.output  = output;
@@ -10,6 +12,7 @@ StatsPlugin.prototype.apply = function (compiler) {
   var options = this.options;
 
   compiler.plugin('done', function (stats) {
+    mkdirp.sync(path.dirname(output));
     fs.writeFileSync(output, JSON.stringify(stats.toJson(options)));
   });
 };

--- a/package.json
+++ b/package.json
@@ -27,8 +27,14 @@
     "webpack": "^1.0"
   },
 
+  "dependencies": {
+    "mkdirp": "^0.5"
+  },
+
   "devDependencies": {
-    "nodeunit": "^0.9",
-    "webpack":  "^1.0"
+    "lodash-node": "^3.0",
+    "nodeunit":    "^0.9",
+    "rimraf":      "^2.0",
+    "webpack":     "^1.0"
   }
 }

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -1,5 +1,7 @@
+var clone = require('lodash-node/modern/lang/clone');
 var fs = require('fs');
 var path = require('path');
+var rimraf = require('rimraf');
 var webpack = require('webpack');
 var StatsPlugin = require('../');
 
@@ -7,13 +9,15 @@ var inputFolder = path.join(__dirname, 'fixtures');
 var inputFile = path.join(inputFolder, 'entry.js');
 var outputFolder = path.join(__dirname, 'output');
 var outputFile = path.join(outputFolder, 'stats.json');
+var newOutputFolder = path.join(__dirname, 'new-output');
+var newOutputFile = path.join(newOutputFolder, 'stats.json');
 
 var options = {
   chunkModules: true,
   exclude: [/node_modules[\\\/]/]
 };
 
-var compiler = webpack({
+var defaultCompilerOptions = {
   entry: inputFile,
 
   output: {
@@ -24,17 +28,36 @@ var compiler = webpack({
   plugins: [
     new StatsPlugin(outputFile, options)
   ]
-});
+}
 
 module.exports.test = {
 
   'generates `stats.json` file': function (test) {
+    var compiler = webpack(defaultCompilerOptions);
     compiler.run(function (err, stats) {
       var expected = JSON.stringify(stats.toJson(options));
       var actual = fs.readFileSync(outputFile);
       test.equal(actual, expected);
       test.done();
     });
-  }
+  },
 
+  'creates directories if they do not exist': function (test) {
+    // Ensure the output folder does not exist
+    rimraf.sync(newOutputFolder);
+
+    var compilerOptions = clone(defaultCompilerOptions, /* isDeep */ true);
+    compilerOptions.output.path = newOutputFolder;
+    compilerOptions.plugins = [
+      new StatsPlugin(newOutputFile, options)
+    ];
+
+    var compiler = webpack(compilerOptions);
+    compiler.run(function (err, stats) {
+      var expected = JSON.stringify(stats.toJson(options));
+      var actual = fs.readFileSync(newOutputFile);
+      test.equal(actual, expected);
+      test.done();
+    });
+  }
 };


### PR DESCRIPTION
If the directory to your stats file doesn't yet exist, this plugin throws an error. Think it's nicer to create the directiry if needed before writing the stats file.