### PR TITLE
Fix size

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ module.exports = {
 ## API
 
 ```js
-new StatsPlugin(filename: string, [options])
+new StatsPlugin(path: string, [options])
 ```
 
-* `filename` the filename of the result file.
-* `options` options passed to [stats.toJson](http://webpack.github.io/docs/node.js-api.html#stats-tojson)
+* `path`: The path of the result file, relative to your output folder.
+* `options`: Options passed to [stats.toJson](http://webpack.github.io/docs/node.js-api.html#stats-tojson)
 
 
 ## Meta

--- a/index.js
+++ b/index.js
@@ -15,12 +15,14 @@ StatsPlugin.prototype.apply = function apply (compiler) {
   var options = this.options
 
   compiler.plugin('emit', function onEmit (compilation, done) {
+    const source = JSON.stringify(compilation.getStats().toJson(options))
+
     compilation.assets[output] = {
       size: function getSize () {
-        return 0
+        return source.length
       },
       source: function getSource () {
-        return JSON.stringify(compilation.getStats().toJson(options))
+        return source
       }
     }
     done()


### PR DESCRIPTION
refs #4 @unindented I've just noticed, actually [it uses relative path](https://github.com/webpack/webpack/blob/master/lib/Stats.js#L165). So the only thing I've fixed is the `size` ouput