### PR TITLE
Add alternative webpack 2 dependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "npm run lint && npm run spec"
   },
   "peerDependencies": {
-    "webpack": "^1.0"
+    "webpack": "^1.0|| ^2.1.0-beta"
   },
   "devDependencies": {
     "chai": "^3.3",
@@ -33,6 +33,6 @@
     "mocha": "^3.0.2",
     "node-libs-browser": "^1.0.0",
     "rimraf": "^2.4",
-    "webpack": "^1.12 || ^2.1.0-beta"
+    "webpack": "^1.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "mocha": "^3.0.2",
     "node-libs-browser": "^1.0.0",
     "rimraf": "^2.4",
-    "webpack": "^1.12"
+    "webpack": "^1.12 || ^2.1.0-beta"
   }
 }


### PR DESCRIPTION
Currently the package triggers an NPM error when used with the webpack 2.x beta releases. It'd be nice to include the beta specifically in a new patch release, until such time webpack 2 becomes stable, which looks to be a ways off.