### PR TITLE
Allow the release candidate as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "npm run lint && npm run spec"
   },
   "peerDependencies": {
-    "webpack": "^1.0|| ^2.1.0-beta"
+    "webpack": "^1.0||^2.1.0-beta||^2.2.0-rc"
   },
   "devDependencies": {
     "chai": "^3.3",


### PR DESCRIPTION
fixes a peer dependency issue.