### PR TITLE
Add support for multi compile mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var _ = require('lodash')
+
 /**
  * Create a new StatsPlugin that causes webpack to generate a stats file as
  * part of the emitted assets.
@@ -5,14 +7,16 @@
  * @param {String} output Path to output file.
  * @param {Object} options Options passed to the stats' `.toJson()`.
  */
-function StatsPlugin (output, options) {
+function StatsPlugin (output, options, cache) {
   this.output = output
   this.options = options
+  this.cache = cache || {}
 }
 
 StatsPlugin.prototype.apply = function apply (compiler) {
   var output = this.output
   var options = this.options
+  var cache = this.cache
 
   compiler.plugin('emit', function onEmit (compilation, done) {
     var result
@@ -22,7 +26,9 @@ StatsPlugin.prototype.apply = function apply (compiler) {
         return result && result.length || 0
       },
       source: function getSource () {
-        result = JSON.stringify(compilation.getStats().toJson(options))
+        var stats = compilation.getStats().toJson(options)
+        cache = _.merge(cache, stats)
+        result = JSON.stringify(cache)
         return result
       }
     }

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "node-libs-browser": "^2.0.0",
     "rimraf": "^2.5.4",
     "webpack": "^1.14.0"
+  },
+  "dependencies": {
+    "lodash": "^4.17.4"
   }
 }

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -32,6 +32,38 @@ var defaultCompilerOptions = {
   ]
 }
 
+var mulitCompilerOptions = (cache) => [{
+  entry: {
+    file1: inputFile
+  },
+
+  output: {
+    path: outputFolder,
+    filename: 'bundle1.js'
+  },
+
+  profile: true,
+
+  plugins: [
+    new StatsPlugin('stats.json', options, cache)
+  ]
+}, {
+  entry: {
+    file2: inputFile
+  },
+
+  output: {
+    path: outputFolder,
+    filename: 'bundle2.js'
+  },
+
+  profile: true,
+
+  plugins: [
+    new StatsPlugin('stats.json', options, cache)
+  ]
+}]
+
 describe('StatsWebpackPlugin', function () {
   beforeEach(function () {
     rimraf.sync(outputFolder)
@@ -60,6 +92,25 @@ describe('StatsWebpackPlugin', function () {
       }
 
       expect(actual).to.deep.equal(expected)
+      done()
+    })
+  })
+
+  it('supports multi-compile mode and outputs one `stats.json` file', function (done) {
+    var cache = {}
+    var compiler = webpack(mulitCompilerOptions(cache))
+    compiler.run(function (err, stats) {
+      if (err) {
+        return done(err)
+      }
+
+      var actual = JSON.parse(fs.readFileSync(outputFile, 'utf8'))
+
+      var expectedAssetsByChunkName = {
+        file1: 'bundle1.js',
+        file2: 'bundle2.js'
+      }
+      expect(actual.assetsByChunkName).to.deep.equal(expectedAssetsByChunkName)
       done()
     })
   })

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -32,7 +32,7 @@ var defaultCompilerOptions = {
   ]
 }
 
-var mulitCompilerOptions = (cache) => [{
+var multiCompilerOptions = (cache) => [{
   entry: {
     file1: inputFile
   },
@@ -98,7 +98,7 @@ describe('StatsWebpackPlugin', function () {
 
   it('supports multi-compile mode and outputs one `stats.json` file', function (done) {
     var cache = {}
-    var compiler = webpack(mulitCompilerOptions(cache))
+    var compiler = webpack(multiCompilerOptions(cache))
     compiler.run(function (err, stats) {
       if (err) {
         return done(err)


### PR DESCRIPTION
Adds support for webpack multi compile mode by adding a cache object. 

Fixes this issue: https://github.com/unindented/stats-webpack-plugin/issues/13

#### Example Usage: 
```js

var StatsPlugin = require('stats-webpack-plugin');

var cache = {};

var config = [{
  ...
  plugins: [
    new StatsPlugin(
      'manifest.json', 
      {
        chunkModules: false,
        source: false,
        chunks: false,
        modules: false,
        assets: true
      }, 
      cache: cache
    )
  ]
  ...
}];
```