### PR TITLE
error and warnings are not persisted across commits

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,8 @@ StatsPlugin.prototype.apply = function apply (compiler) {
 
         if (cache) {
           cache = _.merge(cache, stats)
+          if (stats.errors) cache.errors = stats.errors
+          if (stats.warnings) cache.warnings = stats.warnings
           result = JSON.stringify(cache)
         } else {
           result = JSON.stringify(stats)


### PR DESCRIPTION
This addresses issue 20 https://github.com/unindented/stats-webpack-plugin/issues/20